### PR TITLE
use a O(n) algorithm to get more performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,15 @@ Type: `number`
 
 n-th percentile to calculate; a number between 0 and 100. 
 
+## Alogrithm
+
+Internally, `calc` applies a O(n) algorithm for k'th largest element problem, which get a better performance than ordinary sort method. The following benchmark result can tell more:
+
+```
+percentile#findK x 116,079 ops/sec ±0.54% (97 runs sampled)
+percentile#sort x 16,077 ops/sec ±0.90% (98 runs sampled)
+Fastest is percentile#findK
+```
+
 ## License
 MIT &copy; [Michał Jezierski](https://pl.linkedin.com/in/jezierskimichal)

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,42 @@
+var Suite = require('benchmark').Suite;
+var percentileFindK = require('../');
+var percentileSort = require('./sort.js');
+
+var data1 = [35, 20, 15, 50, 40];
+var data2 = [3, 6, 7, 8, 8, 10, 13, 15, 16, 20];
+var data3 = [3, 6, 7, 8, 8, 9, 10, 13, 15, 16, 20];
+var data4 = [
+  10, 13, 15, 16, 20, 3, 6, 7, 7, 15, 19, 23, 33, 8, 19, 35, 22, 17, 19, 29,
+  13, 13, 15, 16, 22, 3, 8, 7, 1, 14, 19, 23, 33, 8, 19, 35, 21, 17, 19, 29,
+  17, 13, 19, 16, 20, 3, 9, 7, 25, 15, 18, 13, 23, 7, 11, 35, 22, 1, 9, 9,
+  13, 12, 15, 14, 21, 5, 6, 5, 7, 16, 16, 23, 47, 8, 19, 35, 29, 17, 19, 29,
+  15, 13, 15, 8, 20, 3, 6, 7, 7, 17, 19, 23, 43, 8, 19, 35, 22, 17, 19, 9,
+  10, 19, 14, 16, 26, 9, 5, 7, 17, 18, 12, 25, 63, 8, 19, 35, 22, 17, 15, 16
+];
+var data5 = [3];
+
+function run(percentileFn) {
+  [data1, data2, data3, data4, data5].forEach(function (data) {
+    [0, 25, 50, 75, 100].forEach(function (n) {
+      percentileFn(data, n);
+    });
+  });
+};
+
+var suite = new Suite();
+// add tests
+suite.add('percentile#findK', function() {
+  run(percentileFindK.calc);
+})
+.add('percentile#sort', function() {
+  run(percentileSort.calc);
+})
+// add listeners
+.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+.on('complete', function() {
+  console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+})
+// run async
+.run({ 'async': true });

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -39,4 +39,4 @@ suite.add('percentile#findK', function () {
   console.log('Fastest is ' + this.filter('fastest').pluck('name'));
 })
 // run async
-.run();
+.run({ async: true });

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -25,18 +25,18 @@ function run(percentileFn) {
 
 var suite = new Suite();
 // add tests
-suite.add('percentile#findK', function() {
+suite.add('percentile#findK', function () {
   run(percentileFindK.calc);
 })
-.add('percentile#sort', function() {
+.add('percentile#sort', function () {
   run(percentileSort.calc);
 })
 // add listeners
-.on('cycle', function(event) {
+.on('cycle', function (event) {
   console.log(String(event.target));
 })
-.on('complete', function() {
+.on('complete', function () {
   console.log('Fastest is ' + this.filter('fastest').pluck('name'));
 })
 // run async
-.run({ 'async': true });
+.run();

--- a/benchmark/sort.js
+++ b/benchmark/sort.js
@@ -1,6 +1,6 @@
 module.exports = {
   calc: function (data, n) {
-    data = data.sort(function (x, y) {
+    data = data.concat().sort(function (x, y) {
       return x - y;
     });
     return data[Math.ceil(data.length * n / 100) - 1];

--- a/benchmark/sort.js
+++ b/benchmark/sort.js
@@ -1,0 +1,8 @@
+module.exports = {
+  calc: function (data, n) {
+    data = data.sort(function (x, y) {
+      return x - y;
+    });
+    return data[Math.ceil(data.length * n / 100) - 1];
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,14 +1,40 @@
 "use strict";
 
-function sortNumbers(n, m) {
-  return n < m ? -1 : 1;
+function swap(data, i, j) {
+  var tmp = data[j];
+  data[j] = data[i];
+  data[i] = tmp;
+}
+
+function partition(data, start, end) {
+  var pivot = data[start];
+  var i, j, tmp;
+  for (i = start + 1, j = start; i < end; i++) {
+    if (data[i] < pivot) {
+      swap(data, i, ++j);
+    }
+  }
+  swap(data, start, j);
+  return j;
+}
+
+function findK(data, start, end, k) {
+  while (start < end) {
+    var pos = partition(data, start, end);
+    if (pos === k) {
+      return data[k];
+    } else if (pos > k) {
+      end = pos;
+    } else {
+      start = pos + 1;
+    }
+  }
 }
 
 module.exports = {
   // Calculate n-th percentile of 'data' using Nearest Rank Method
   // http://en.wikipedia.org/wiki/Percentile#The_Nearest_Rank_method
   calc: function (data, n) {
-    data.sort(sortNumbers);
-    return data[Math.ceil(data.length * n / 100) - 1];
+    return findK(data.concat(), 0, data.length, Math.ceil(data.length * n / 100) - 1);
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 "use strict";
 
 function swap(data, i, j) {
-  if (i === j) return;
-  var tmp = data[j];
+  var tmp;
+  if (i === j) {
+    return;
+  }
+  tmp = data[j];
   data[j] = data[i];
   data[i] = tmp;
 }
@@ -20,11 +23,13 @@ function partition(data, start, end) {
 }
 
 function findK(data, start, end, k) {
+  var pos;
   while (start < end) {
-    var pos = partition(data, start, end);
+    pos = partition(data, start, end);
     if (pos === k) {
       return data[k];
-    } else if (pos > k) {
+    }
+    if (pos > k) {
       end = pos;
     } else {
       start = pos + 1;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 function swap(data, i, j) {
+  if (i === j) return;
   var tmp = data[j];
   data[j] = data[i];
   data[i] = tmp;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Calculate Nth percentile of a list of values",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/mocha test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "url": "https://github.com/msn0/stats-percentile/issues"
   },
   "homepage": "https://github.com/msn0/stats-percentile",
-  "dependencies": {
-    "mocha": "^2.2.4"
+  "devDependencies": {
+    "mocha": "^2.2.4",
+    "benchmark": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Calculate Nth percentile of a list of values",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test.js"
+    "test": "./node_modules/.bin/mocha test.js",
+    "benchmark": "node benchmark/index.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -15,6 +15,7 @@ describe("Percentile calculation", function () {
       15, 13, 15, 8, 20, 3, 6, 7, 7, 17, 19, 23, 43, 8, 19, 35, 22, 17, 19, 9,
       10, 19, 14, 16, 26, 9, 5, 7, 17, 18, 12, 25, 63, 8, 19, 35, 22, 17, 15, 16
     ];
+    var data5 = [3];
 
     assert.equal(percentile.calc(data1, 30), 20);
     assert.equal(percentile.calc(data1, 40), 20);
@@ -37,5 +38,10 @@ describe("Percentile calculation", function () {
     assert.equal(percentile.calc(data4, 95), 35);
     assert.equal(percentile.calc(data4, 99), 47);
     assert.equal(percentile.calc(data4, 100), 63);
+
+    assert.equal(percentile.calc(data5, 25), 3);
+    assert.equal(percentile.calc(data5, 50), 3);
+    assert.equal(percentile.calc(data5, 75), 3);
+    assert.equal(percentile.calc(data5, 100), 3);
   });
 });


### PR DESCRIPTION
kth largest element is a famous question, and there is a O(n) algorithm based on quicksort. It's much faster than the O(n*log(n)) `sort` method, as shown by the new added benchmarking:

```
percentile#findK x 116,079 ops/sec ±0.54% (97 runs sampled)
percentile#sort x 16,077 ops/sec ±0.90% (98 runs sampled)
Fastest is percentile#findK
```
